### PR TITLE
conf: add port to throw-to-launch command sending

### DIFF
--- a/main.conf
+++ b/main.conf
@@ -21,6 +21,11 @@ Mode = Eavesdropping
 Address = 127.0.0.1
 Port = 14553
 
+[UdpEndpoint buttond]
+Mode = Normal
+Address = 127.0.0.1
+Port = 14570
+
 [UdpEndpoint mhpm]
 Mode = Normal
 Address = 127.0.0.1


### PR DESCRIPTION
Adds port so that the button scripts can send/rcv MAVLink msgs and commands (ex: throw-to-launch activation).