### PR TITLE
Add encryption key forwarding UDP port

### DIFF
--- a/main.conf
+++ b/main.conf
@@ -26,6 +26,11 @@ Mode = Normal
 Address = 127.0.0.1
 Port = 14570
 
+[UdpEndpoint encrypt-key]
+Mode = Normal
+Address = 127.0.0.1
+Port = 14571
+
 [UdpEndpoint mhpm]
 Mode = Normal
 Address = 127.0.0.1


### PR DESCRIPTION
Adds a UDP port so the `encryption-key-reader.py` script can forward the `AUTH_KEY` Mavlink msg to the FMU.

Related: https://github.com/TealDrones/teal-mk1-build/pull/12.