### PR TITLE
Adding gimbal conman port to mavlink router

### DIFF
--- a/main.conf
+++ b/main.conf
@@ -21,6 +21,11 @@ Mode = Eavesdropping
 Address = 127.0.0.1
 Port = 14553
 
+[UdpEndpoint gimbal]
+Mode = Eavesdropping
+Address = 127.0.0.1
+Port = 14554
+
 [UdpEndpoint buttond]
 Mode = Normal
 Address = 127.0.0.1


### PR DESCRIPTION
The gimbal controller / manager (conman) has it's own port.