### PR TITLE
Logger

### DIFF
--- a/buildMav.sh
+++ b/buildMav.sh
@@ -1,4 +1,4 @@
-source /usr/local/rb3-oecore-x86_64/environment-setup-aarch64-oe-linux
+source /usr/local/teal-oecore-x86_64/environment-setup-aarch64-oe-linux
 ./autogen.sh
 ./configure CFLAGS='-g -O2' \
     --sysconfdir=/etc \
@@ -10,7 +10,7 @@ make clean
 python ./modules/mavlink/pymavlink/tools/mavgen.py -o include/mavlink --lang C --wire-protocol 2.0 modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
 if make -j10; then
     echo "+++++++++++++ Success "
-    scp mavlink-routerd pi@dmz.tealdrones.com:~/code/distro/
+    #scp mavlink-routerd pi@dmz.tealdrones.com:~/code/distro/
     exit 0
 else
     echo "------------- Fail "

--- a/logger.conf
+++ b/logger.conf
@@ -1,0 +1,11 @@
+[General]
+ReportStats=false
+MavlinkDialect=common
+Log=/data/teal/flight-logs
+LogMode=while-armed
+MaxLogFiles=25
+
+[UartEndpoint Logging]
+Device = /dev/ttyFMU
+Baud = 921600
+

--- a/main.conf
+++ b/main.conf
@@ -5,10 +5,10 @@ Log=/data/teal/flight-logs
 LogMode=while-armed
 MaxLogFiles=25
 
-[UartEndpoint px4]
-Device = /dev/ttyHS1
-Baud = 921600
-FlowControl = True
+#[UartEndpoint px4]
+#Device = /dev/ttyHS1
+#Baud = 921600
+#FlowControl = True
 
 [UdpEndpoint qgc]
 Mode = Normal
@@ -44,7 +44,3 @@ Port = 14571
 Mode = Normal
 Address = 127.0.0.1
 Port = 14531
-
-[UartEndpoint Logging]
-Device = /dev/ttyFMU
-Baud = 921600

--- a/main.conf
+++ b/main.conf
@@ -1,24 +1,15 @@
 [General]
 ReportStats=false
-MavlinkDialect=common
-Log=/data/teal/flight-logs
-LogMode=while-armed
-MaxLogFiles=25
 
-#[UartEndpoint px4]
-#Device = /dev/ttyHS1
-#Baud = 921600
-#FlowControl = True
+[UartEndpoint px4]
+Device = /dev/ttyHS1
+Baud = 921600
+FlowControl = True
 
-[UdpEndpoint qgc]
+[UdpEndpoint mhpm]
 Mode = Normal
-Address = 192.168.168.200
-Port = 14550
-
-[UdpEndpoint Mfg]
-Mode = Normal
-Address = 192.168.1.2
-Port = 14540
+Address = 127.0.0.1
+Port = 14531
 
 [UdpEndpoint camera]
 Mode = Eavesdropping
@@ -35,12 +26,18 @@ Mode = Normal
 Address = 127.0.0.1
 Port = 14570
 
-[UdpEndpoint encrypt-key]
-Mode = Normal
-Address = 127.0.0.1
-Port = 14571
+#[UdpEndpoint qgc]
+#Mode = Normal
+#Address = 192.168.168.200
+#Port = 14550
 
-[UdpEndpoint mhpm]
-Mode = Normal
-Address = 127.0.0.1
-Port = 14531
+#[UdpEndpoint Mfg]
+#Mode = Normal
+#Address = 192.168.1.2
+#Port = 14540
+
+#[UdpEndpoint encrypt-key]
+#Mode = Normal
+#Address = 127.0.0.1
+#Port = 14571
+

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -35,7 +35,7 @@
 #include "endpoint.h"
 #include "mainloop.h"
 
-#define TEAL_VERSION "0.0.09"
+#define TEAL_VERSION "0.0.09a"
 #define MAVLINK_TCP_PORT 5760
 #define DEFAULT_BAUDRATE 115200U
 #define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -55,7 +55,7 @@ static struct options opt = {
     .min_free_space = 0,
     .max_log_files = 0,
     .heartbeat = false,
-    .ignore_pipe = false
+    .use_pipe = true
 };
 
 static const struct option long_options[] = {
@@ -393,6 +393,7 @@ static bool pre_parse_argv(int argc, char *argv[])
         }
         case 'V':
             puts(PACKAGE " version " VERSION);
+            puts(PACKAGE " Teal version " TEAL_VERSION);
             return false;
         }
     }
@@ -485,7 +486,7 @@ static int parse_argv(int argc, char *argv[])
             break;
         }
         case 'i':
-            opt.ignore_pipe = true;
+            opt.use_pipe = false;
             break;
         case 'c':
         case 'd':
@@ -924,11 +925,14 @@ int main(int argc, char *argv[])
     if (opt.tcp_port == ULONG_MAX)
         opt.tcp_port = MAVLINK_TCP_PORT;
 
+    if (opt.use_pipe)
+        mainloop.start_fifo();
+    else
+        log_info("Ignoring pipe");
+
     if (!mainloop.add_endpoints(mainloop, &opt))
         goto endpoint_error;
     
-    mainloop.set_ignore_pipe(opt.ignore_pipe);
-
     mainloop.loop();
 
     free_endpoints_options_strings(&opt);

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -35,7 +35,7 @@
 #include "endpoint.h"
 #include "mainloop.h"
 
-#define TEAL_VERSION "0.0.09a"
+#define TEAL_VERSION "0.0.10"
 #define MAVLINK_TCP_PORT 5760
 #define DEFAULT_BAUDRATE 115200U
 #define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"
@@ -54,13 +54,15 @@ static struct options opt = {
     .mavlink_dialect = Auto,
     .min_free_space = 0,
     .max_log_files = 0,
-    .heartbeat = false
+    .heartbeat = false,
+    .ignore_pipe = false
 };
 
 static const struct option long_options[] = {
     { "endpoints",              required_argument,  NULL,   'e' },
     { "conf-file",              required_argument,  NULL,   'c' },
     { "conf-dir" ,              required_argument,  NULL,   'd' },
+    { "ignore-pipe",            no_argument,        NULL,   'i' },
     { "report_msg_statistics",  no_argument,        NULL,   'r' },
     { "tcp-port",               required_argument,  NULL,   't' },
     { "tcp-endpoint",           required_argument,  NULL,   'p' },
@@ -72,7 +74,7 @@ static const struct option long_options[] = {
     { }
 };
 
-static const char* short_options = "he:rt:c:d:l:p:g:bvV";
+static const char* short_options = "he:rt:c:d:l:p:g:bvVi";
 
 static void help(FILE *fp) {
     fprintf(fp,
@@ -93,6 +95,7 @@ static void help(FILE *fp) {
             "  -c --conf-file <file>        .conf file with configurations for mavlink-router.\n"
             "  -d --conf-dir <dir>          Directory where to look for .conf files overriding\n"
             "                               default conf file.\n"
+            "  -i --ignore-pipe             Ignore all piped messages (i.e. dynamic endpoints)\n"
             "  -l --log <directory>         Enable Flight Stack logging\n"
             "  -g --debug-log-level <level> Set debug log level. Levels are\n"
             "                               <error|warning|info|debug>\n"
@@ -481,6 +484,9 @@ static int parse_argv(int argc, char *argv[])
             free(ip);
             break;
         }
+        case 'i':
+            opt.ignore_pipe = true;
+            break;
         case 'c':
         case 'd':
         case 'V':
@@ -920,6 +926,8 @@ int main(int argc, char *argv[])
 
     if (!mainloop.add_endpoints(mainloop, &opt))
         goto endpoint_error;
+    
+    mainloop.set_ignore_pipe(opt.ignore_pipe);
 
     mainloop.loop();
 

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -35,7 +35,7 @@
 #include "endpoint.h"
 #include "mainloop.h"
 
-#define TEAL_VERSION "0.0.10"
+#define TEAL_VERSION "0.0.10a"
 #define MAVLINK_TCP_PORT 5760
 #define DEFAULT_BAUDRATE 115200U
 #define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"
@@ -925,8 +925,10 @@ int main(int argc, char *argv[])
     if (opt.tcp_port == ULONG_MAX)
         opt.tcp_port = MAVLINK_TCP_PORT;
 
-    if (opt.use_pipe)
+    if (opt.use_pipe) {
+        log_info("Seting up pipe");
         mainloop.start_fifo();
+    }
     else
         log_info("Ignoring pipe");
 

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -35,7 +35,7 @@
 #include "endpoint.h"
 #include "mainloop.h"
 
-#define TEAL_VERSION "0.0.10a"
+#define TEAL_VERSION "0.0.10"
 #define MAVLINK_TCP_PORT 5760
 #define DEFAULT_BAUDRATE 115200U
 #define DEFAULT_CONFFILE "/etc/mavlink-router/main.conf"

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -926,7 +926,7 @@ int main(int argc, char *argv[])
         opt.tcp_port = MAVLINK_TCP_PORT;
 
     if (opt.use_pipe) {
-        log_info("Seting up pipe");
+        log_info("Setting up pipe");
         mainloop.start_fifo();
     }
     else

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -317,7 +317,7 @@ int Mainloop::run_single(int timeout_msec)
         return 0;
     }
     for (int i = 0; i < r; i++) {
-        if (events[i].data.ptr == &_pipefd) {
+        if (events[i].data.ptr == &_pipefd && !get_should_ignore_pipe()) {
             _handle_pipe();
             continue;
         }

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -56,6 +56,7 @@ public:
 
     ~Mainloop();
 
+    void start_fifo();
     int add_fd(int fd, void *data, int events);
     int mod_fd(int fd, void *data, int events);
     int remove_fd(int fd);
@@ -85,10 +86,6 @@ public:
     bool add_dynamic_endpoint(const dynamic_command& command);
     bool remove_dynamic_endpoint(const dynamic_command& command);
     bool remove_dynamic_endpoint(Endpoint *endpoint);
-
-    inline bool get_should_ignore_pipe() {return _ignore_pipe;}
-
-    inline void set_ignore_pipe(bool ignore){_ignore_pipe = ignore;}
 
     void print_statistics();
 
@@ -154,8 +151,6 @@ private:
     bool _log_aggregate_timeout(void *data);
     void _handle_pipe();
 
-    bool _ignore_pipe{false};
-
     static Mainloop* instance;
 };
 
@@ -213,5 +208,5 @@ struct options {
     unsigned long min_free_space;
     unsigned long max_log_files;
     bool heartbeat;
-    bool ignore_pipe;
+    bool use_pipe;
 };

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -86,6 +86,10 @@ public:
     bool remove_dynamic_endpoint(const dynamic_command& command);
     bool remove_dynamic_endpoint(Endpoint *endpoint);
 
+    inline bool get_should_ignore_pipe() {return _ignore_pipe;}
+
+    inline void set_ignore_pipe(bool ignore){_ignore_pipe = ignore;}
+
     void print_statistics();
 
     int epollfd = -1;
@@ -150,6 +154,8 @@ private:
     bool _log_aggregate_timeout(void *data);
     void _handle_pipe();
 
+    bool _ignore_pipe{false};
+
     static Mainloop* instance;
 };
 
@@ -207,4 +213,5 @@ struct options {
     unsigned long min_free_space;
     unsigned long max_log_files;
     bool heartbeat;
+    bool ignore_pipe;
 };


### PR DESCRIPTION
Added flag (--ignore-pipe, -i) to mavlink-routerd to disable initialization and use of the pipe. 
The pairing manager uses the pipe to dynamically set up endpoints.
Excluding the use of the pipe is needed to allow a second instance of mavlink-router to be used exclusively for mavlink-router logging.